### PR TITLE
adding option to skip or replace if table already exists #127

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ bin/
 *.sln.docstates
 
 # also adding launchsettings here
-launchsettings.json
+# launchsettings.json
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/backend/src/BIE.DataPipeline/DBHelper.cs
+++ b/backend/src/BIE.DataPipeline/DBHelper.cs
@@ -3,6 +3,7 @@ using BIE.Data;
 using BIE.DataPipeline.Import;
 using System.Data.Common;
 using Microsoft.Data.SqlClient;
+using static BIE.DataPipeline.Import.DataSourceDescription.DataSourceOptions;
 
 namespace BIE.DataPipeline
 {
@@ -43,7 +44,7 @@ namespace BIE.DataPipeline
 
             var db = Database.Instance;
 
-            if (description.options.if_table_exists == "skip")
+            if (description.options.if_table_exists == InsertBehaviour.skip)
             {
                 var tableExists =
                     (int)db.ExecuteScalar(db.CreateCommand($"SELECT count(*) as Exist" +
@@ -57,9 +58,9 @@ namespace BIE.DataPipeline
                 }
             }
 
-            if (description.options.if_table_exists == "replace")
+            if (description.options.if_table_exists == InsertBehaviour.replace)
             {
-                Console.WriteLine($"Dropping existing table {description.table_name}");
+                Console.WriteLine($"Dropping table {description.table_name} if it exists.");
                 db.ExecuteScalar(db.CreateCommand($"DROP TABLE IF EXISTS {description.table_name}"));
             }
             

--- a/backend/src/BIE.DataPipeline/Import/YamlImporter.cs
+++ b/backend/src/BIE.DataPipeline/Import/YamlImporter.cs
@@ -86,18 +86,25 @@ namespace BIE.DataPipeline.Import
             /// </summary>
             public bool discard_null_rows { get; set; }
 
-            private string mIf_table_exists = "skip";
+            private InsertBehaviour mIf_table_exists = InsertBehaviour.skip;
 
             /// <summary>
             /// How to deal with an existing table in the database. Options:
             /// "skip": skip this dataset, is the default
-            /// "none": do nothing special
+            /// "ignore": do nothing special
             /// "replace": DROP the existing table before inserting data.
             /// </summary>
-            public string if_table_exists
+            public InsertBehaviour if_table_exists
             {
                 get => mIf_table_exists;
                 set => mIf_table_exists = value;
+            }
+            
+            public enum InsertBehaviour
+            {
+                ignore,
+                skip,
+                replace
             }
         }
 

--- a/backend/src/BIE.DataPipeline/Import/YamlImporter.cs
+++ b/backend/src/BIE.DataPipeline/Import/YamlImporter.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Text;
 using YamlDotNet.Serialization;
+
 // ReSharper disable InconsistentNaming
 
 namespace BIE.DataPipeline.Import
@@ -49,6 +50,7 @@ namespace BIE.DataPipeline.Import
         /// </summary>
         public string table_name { get; set; }
 
+
         /// <summary>
         /// the delimiter used in the csv datasource.
         /// </summary>
@@ -77,12 +79,26 @@ namespace BIE.DataPipeline.Import
             /// <summary>
             /// The number of initial lines to skip while reading the data source.
             /// </summary>
-            public int skip_lines {get; set;}
+            public int skip_lines { get; set; }
 
             /// <summary>
             /// Indicates whether to discard rows with null values.
             /// </summary>
-            public bool discard_null_rows {get; set;}
+            public bool discard_null_rows { get; set; }
+
+            private string mIf_table_exists = "skip";
+
+            /// <summary>
+            /// How to deal with an existing table in the database. Options:
+            /// "skip": skip this dataset, is the default
+            /// "none": do nothing special
+            /// "replace": DROP the existing table before inserting data.
+            /// </summary>
+            public string if_table_exists
+            {
+                get => mIf_table_exists;
+                set => mIf_table_exists = value;
+            }
         }
 
         public class DataSourceColumn
@@ -90,7 +106,7 @@ namespace BIE.DataPipeline.Import
             /// <summary>
             /// The name of the column in the datasource.
             /// </summary>
-            public string name {get; set;}
+            public string name { get; set; }
 
             /// <summary>
             /// The name of the column in the database table.
@@ -98,9 +114,11 @@ namespace BIE.DataPipeline.Import
             public string name_in_table { get; set; }
 
             private string mType = "VARCHAR(500)";
+
             /// <summary>
             /// The data type of the column.
-            public string type {
+            public string type
+            {
                 get => mType;
                 set => mType = value;
             }

--- a/backend/src/BIE.DataPipeline/Program.cs
+++ b/backend/src/BIE.DataPipeline/Program.cs
@@ -11,9 +11,11 @@ CsvImporter csvImporter = new CsvImporter(description);
 
 var dbHelper = new DBHelper();
 dbHelper.SetInfo(csvImporter.GetTableName(), csvImporter.GetHeaderString());
-dbHelper.CreateTable(description);
 
-
+if (!dbHelper.CreateTable(description))
+{
+    return 0;
+}
 
 //Console.WriteLine(csvImporter.GetHeaderString());
 string line = "";
@@ -52,3 +54,5 @@ if (false)
 }
 Console.WriteLine();
 Console.WriteLine("Parser End");
+
+return 0;

--- a/backend/src/BIE.DataPipeline/Properties/launchsettings.json
+++ b/backend/src/BIE.DataPipeline/Properties/launchsettings.json
@@ -1,0 +1,17 @@
+{
+  "profiles": {
+    "BIE.DataPipeline": {
+      "commandName": "Project",
+      "commandLineArgs": "test.yaml",
+      "workingDirectory": "yaml",
+      "environmentVariables": {
+        "DB_SERVER": "localhost",
+        "DB_NAME": "BIEDB",
+        "DB_PASSWORD": "MyPass@1234",
+        "DB_USERNAME": "db_user1",
+        "DB_TYPE": "SQL",
+        "TRUSTED": "True"
+      }
+    }
+  }
+}

--- a/backend/src/BIE.DataPipeline/yaml/test.yaml
+++ b/backend/src/BIE.DataPipeline/yaml/test.yaml
@@ -8,7 +8,7 @@ options:
   skip_lines: 10
   # discard any rows that have null values
   discard_null_rows: false
-  # how to deal with existing table. Options: noop, replace, skip (default).
+  # how to deal with existing table. Options: ignore, replace, skip (default).
   if_table_exists: replace
 table_name: EV_charging_stations
 delimiter: ";"

--- a/backend/src/BIE.DataPipeline/yaml/test.yaml
+++ b/backend/src/BIE.DataPipeline/yaml/test.yaml
@@ -8,6 +8,8 @@ options:
   skip_lines: 10
   # discard any rows that have null values
   discard_null_rows: false
+  # how to deal with existing table. Options: noop, replace, skip (default).
+  if_table_exists: replace
 table_name: EV_charging_stations
 delimiter: ";"
 
@@ -69,4 +71,3 @@ table_cols:
     name_in_table: power_4_kw
   - name: Public Key4
     name_in_table: public_key_4
-


### PR DESCRIPTION
- added yaml option if_table_exists
  - can have values: skip (default), replace, noop
  - skip : stop execution if table already exists.
  - replace: DROP table before creating it again.
  - ignore: insert into existing table.
- a wrong value will throw an exception.
